### PR TITLE
Remove dollar signs from README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ SE 2021 fall semester project
 Clone the repo to your machine:
 
 ```
-$ git clone https://github.com/indiana-tech-software-engineering/drug-drug-interaction.git
+git clone https://github.com/indiana-tech-software-engineering/drug-drug-interaction.git
 ```
 
 Navigate to the web app directory and restore Nuget packages:
 
 ```
-$ cd drug-drug-interaction/DDI.WebApp
-$ dotnet restore
+cd drug-drug-interaction/DDI.WebApp
+dotnet restore
 ```
 
 Run the web app:
 
 ```
-$ dotnet run
+dotnet run
 ```
 
 ## Notes


### PR DESCRIPTION
This makes it so that people can copy commands from the snippets in the README without dealing with invalid syntax.